### PR TITLE
fix library installation command using go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo mv kubectl-explore /usr/local/bin
 ### Source
 
 ```shell
-go install github.com/kei6u/kubectl-explore
+go install github.com/kei6u/kubectl-explore@0.1.0
 sudo mv $GOPATH/bin/kubectl-explore /usr/local/bin
 ```
 


### PR DESCRIPTION
`go install` can install an executable binary, but if the version suffix is missing, it tries to install the given package with module-aware mode. (ref: [New module changes in Go 1.16 - The Go Programming Language](https://go.dev/blog/go116-module-changes))

As a result, if the command is run outside of any Go module, it shows the below error:

```
$ cd $HOME # not inside of any module
$ go install github.com/kei6u/kubectl-explore
go install: version is required when current directory is not in a module
	Try 'go install github.com/kei6u/kubectl-explore@latest' to install the latest version
```

By appending the suffix ( `@0.1.0` or even `@latest` should be OK), it successfully installs the command.

Another reference: [Deprecation of 'go get' for installing executables - The Go Programming Language](https://go.dev/doc/go-get-install-deprecation)