### PR TITLE
Update goreleaser configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,23 +2,21 @@ name: release
 on:
   push:
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - 'v*.*.*'
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - name: Setup Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.17
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+    - name: GoReleaser
+      uses: goreleaser/goreleaser-action@v1
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,27 @@
-project_name: kubectl-explore
 before:
   hooks:
-    - go mod tidy
+  - go mod download
 builds:
-  - binary: kubectl-explore
-    ldflags:
-      - -s -w
-      - -X main.Version={{.Version}}
-      - -X main.Revision={{.ShortCommit}}
-    env:
-      - CGO_ENABLED=0
+- id: kubectl-explore
+  binary: kubectl-explore
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore:
+  - goos: windows
+    goarch: arm64
+
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
-    format_overrides:
-      - goos: windows
-        format: zip
-release:
-  prerelease: auto
+- builds:
+  - kubectl-explore
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  wrap_in_directory: "false"
+  format: tar.gz
+  files:
+  - LICENSE

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Download the binary from [GitHub Releases](https://github.com/kei6u/kubectl-expl
 ### Linux
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_linux_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_linux_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
@@ -80,7 +80,7 @@ sudo mv kubectl-explore /usr/local/bin
 ### Darwin(amd64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_darwin_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
@@ -88,7 +88,7 @@ sudo mv kubectl-explore /usr/local/bin
 ### Darwin(arm64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_darwin_arm64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_arm64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```

--- a/README.md
+++ b/README.md
@@ -72,15 +72,23 @@ Download the binary from [GitHub Releases](https://github.com/kei6u/kubectl-expl
 ### Linux
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.1/kubectl-explore_linux_x86_64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_linux_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
 
-### OSX
+### Darwin(amd64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.1/kubectl-explore_darwin_x86_64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_darwin_amd64.tar.gz
+tar -xvf kubectl-explore.tar.gz
+sudo mv kubectl-explore /usr/local/bin
+```
+
+### Darwin(arm64)
+
+```shell
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2-beta.1/kubectl-explore_v0.3.2-beta.1_darwin_arm64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```


### PR DESCRIPTION
I have updated goreleaser config and related with reference to the following.
- https://github.com/ahmetb/kubectl-tree/blob/master/.github/workflows/release.yml 
- https://github.com/ahmetb/kubectl-tree/blob/master/.goreleaser.yml

After merging this PR, I will create `v0.3.2` tag.