### PR TITLE
Krew Support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,5 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update new version in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,42 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: explore
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/kei6u/kubectl-explore
+  shortDescription: A better kubectl explain with the fuzzy finder
+  description: |
+    Fuzzy-find and explain the fields associated with
+    supported API resource.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/kei6u/kubectl-explore/releases/download/{{ .TagName }}/kubectl-explore{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/kei6u/kubectl-explore/releases/download/{{ .TagName }}/kubectl-explore{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/kei6u/kubectl-explore/releases/download/{{ .TagName }}/kubectl-explore{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/kei6u/kubectl-explore/releases/download/{{ .TagName }}/kubectl-explore{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/kei6u/kubectl-explore/releases/download/{{ .TagName }}/kubectl-explore{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
+    bin: kubectl-explore.exe

--- a/README.md
+++ b/README.md
@@ -66,42 +66,54 @@ Flags:
       --username string                Username for basic authentication to the API server
 ```
 
-## Install
+## Installation
+
+### Krew
+
+Use [krew](https://krew.sigs.k8s.io/) plugin manager to install.
+See [the guide](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) to install [krew](https://krew.sigs.k8s.io/).
+
+```bash
+kubectl krew install explore
+kubectl explore --help
+```
+
+### Download the binary
 
 Download the binary from [GitHub Releases](https://github.com/kei6u/kubectl-explore/releases) and drop it in your `$PATH`.
 
-### Linux
+#### Linux
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_linux_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_linux_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
 
-### Darwin(amd64)
+#### Darwin(amd64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_darwin_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
 
-### Darwin(arm64)
+#### Darwin(arm64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_arm64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_darwin_arm64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
 
-### Source
+#### Source
 
 ```shell
 go install github.com/kei6u/kubectl-explore@latest
 sudo mv $GOPATH/bin/kubectl-explore /usr/local/bin
 ```
 
-### Validation
+#### Validation
 
 Validate if `kubectl explore` can be executed.
 [The Kubernetes documentation](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/#using-a-plugin) explains how to use a plugin.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Download the binary from [GitHub Releases](https://github.com/kei6u/kubectl-expl
 #### Linux
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_linux_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.4.0/kubectl-explore_v0.4.0_linux_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
@@ -93,7 +93,7 @@ sudo mv kubectl-explore /usr/local/bin
 #### Darwin(amd64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_darwin_amd64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.4.0/kubectl-explore_v0.4.0_darwin_amd64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```
@@ -101,7 +101,7 @@ sudo mv kubectl-explore /usr/local/bin
 #### Darwin(arm64)
 
 ```shell
-curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.3.3/kubectl-explore_v0.3.3_darwin_arm64.tar.gz
+curl -L -o kubectl-explore.tar.gz https://github.com/kei6u/kubectl-explore/releases/download/v0.4.0/kubectl-explore_v0.4.0_darwin_arm64.tar.gz
 tar -xvf kubectl-explore.tar.gz
 sudo mv kubectl-explore /usr/local/bin
 ```


### PR DESCRIPTION
This pr is blocked by https://github.com/kubernetes-sigs/krew-index/pull/1891 and solves https://github.com/kei6u/kubectl-explore/issues/2

I updated as follows.
- Added krew-release-bot to GitHub Actions according to this [yaml](https://github.com/ahmetb/kubectl-tree/blob/e38ce2b7cef124492aef58cc2c5cc0606a7e5b84/.github/workflows/release.yml#L23-L24).
- Added `.krew.yaml` for the bot above according to this [.krew.yaml](https://github.com/ahmetb/kubectl-tree/blob/e38ce2b7cef124492aef58cc2c5cc0606a7e5b84/.krew.yaml#L1-L41).
- Edited README to add the krew installation guide.